### PR TITLE
Add economy3_provenance_attestation RAVE template

### DIFF
--- a/library/economy3_provenance_attestation/README.md
+++ b/library/economy3_provenance_attestation/README.md
@@ -1,0 +1,47 @@
+# Economy3 Provenance Attestation Credit
+
+## What This Is
+
+A Unyt Smart Agreement that issues 1 E3 attestation credit to a producer each time they sign a verified provenance record in the Economy3 Heritage app.
+
+**The economic loop:**
+1. A brand/buyer parks N E3 base units against this agreement — one per expected attestation in their supply chain.
+2. The Economy3 Gateway (automated executor) harvests SignedFact logs from the Holochain DHT (or Postgres bridge during the Q2 interim period).
+3. For each valid log, the producer identified by `creator_did` receives 1 E3.
+4. Authority-only records (privacy tier 3) are excluded — their parked spend is returned to the brand.
+
+## Roles
+
+| Role | Who | What they do |
+|------|-----|--------------|
+| `spender` | Brand / buyer | Parks Base Unit spend against this agreement |
+| `executor` | Economy3 Gateway | Harvests logs, runs RAVE execution |
+| Receiver (implicit) | Producer / artisan | Accepts credit once allocated |
+
+## SignedFact Log Blob Format
+
+Each log data blob is a JSON object with these fields:
+
+```json
+{
+  "record_id":     "E3-20260403-001",
+  "resource_hash": "abc123...",
+  "material":      "Upland Cotton",
+  "step":          "harvest",
+  "creator_did":   "uhCAk...",
+  "qty":           500,
+  "unit":          "KG",
+  "privacy_tier":  0
+}
+```
+
+`step` values: `plant` | `grow` | `harvest` | `process` | `pack` | `handoff`
+
+## Credit Logic (v1)
+
+- **1 E3 per attestation**, regardless of material, quantity, or step.
+- Future versions can weight by step or material using a `price_sheet` data blob (see `holo_hosting_proof_of_service` for that pattern).
+
+## Status
+
+Ready for import into a Unyt Alliance once the Holochain Q2 web service ships and the Economy3 `qr_infra` DNA is running on-chain. Currently modeled in Postgres (`credit_ledger` table in economy3-web).

--- a/library/economy3_provenance_attestation/README.md
+++ b/library/economy3_provenance_attestation/README.md
@@ -6,7 +6,7 @@ A Unyt Smart Agreement that issues 1 E3 attestation credit to a producer each ti
 
 **The economic loop:**
 1. A brand/buyer parks N E3 base units against this agreement — one per expected attestation in their supply chain.
-2. The Economy3 Gateway (automated executor) harvests SignedFact logs from the Holochain DHT (or Postgres bridge during the Q2 interim period).
+2. The Economy3 Gateway (automated executor) harvests SignedFact logs from PostgreSQL (primary) or the Holochain DHT when a conductor is available.
 3. For each valid log, the producer identified by `creator_did` receives 1 E3.
 4. Authority-only records (privacy tier 3) are excluded — their parked spend is returned to the brand.
 

--- a/library/economy3_provenance_attestation/agreement_definition_input.json
+++ b/library/economy3_provenance_attestation/agreement_definition_input.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "expected_roles": {
+      "type": "array",
+      "items": [
+        {
+          "const": {
+            "id": "spender",
+            "parked_link_type": "ParkedSpendCredit",
+            "description": "Brand or buyer who parks Base Units to fund producer attestation credits"
+          }
+        },
+        {
+          "const": {
+            "id": "executor",
+            "parked_link_type": "ParkedData",
+            "description": "Economy3 Gateway — automated agent that harvests SignedFact logs and executes this agreement"
+          }
+        }
+      ],
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true
+    }
+  },
+  "required": ["expected_roles"],
+  "additionalProperties": false
+}

--- a/library/economy3_provenance_attestation/execution_code.rhai
+++ b/library/economy3_provenance_attestation/execution_code.rhai
@@ -1,0 +1,82 @@
+/// Subject: Economy3 Provenance Attestation Credit
+///
+/// Users:
+/// - Brand / Buyer (Spender):
+///     Parks spend in Base Units against this agreement to fund producer credits
+///     for each verified provenance attestation in their supply chain.
+/// - Economy3 Gateway (Executor):
+///     Automated agent that harvests SignedFact logs from the DHT (or Postgres
+///     bridge) and executes this agreement on behalf of the spender.
+/// - Producer / Artisan (Receiver):
+///     The smallholder, gin, loom, or factory agent whose signed attestation
+///     triggered the credit. Identified by creator_did in the SignedFact payload.
+///
+/// Inputs:
+/// - logs: data blobs, each containing one Economy3 SignedFact:
+///     {
+///       "record_id":     string,  // Economy3 record ID (e.g. E3-20260403-001)
+///       "resource_hash": string,  // Postgres / DHT content hash
+///       "material":      string,  // e.g. "Upland Cotton"
+///       "step":          string,  // Heritage step: plant | grow | harvest |
+///                                 //   process | pack | handoff
+///       "creator_did":   string,  // Producer's DID / Holochain agent key
+///       "qty":           number,  // quantity attested
+///       "unit":          string,  // KG | MT | bale | yard
+///       "privacy_tier":  number   // 0=public 1=alias 2=community 3=authorities
+///     }
+/// - spender_allocations: parked Base Unit spend from the brand, one entry
+///   per attestation log, cross-checked against expected credit.
+///
+/// Credit logic:
+/// - 1 E3 attestation credit per SignedFact log.
+///   (Future: weight by step, quantity, or material via a price_sheet data blob.)
+/// - Privacy tier 3 records are excluded — authority-only records do not earn
+///   public credits. Their spend allocation is returned to the spender.
+///
+/// Summary:
+/// 1. Brand parks N E3 base units against this agreement (one per expected attestation).
+/// 2. Economy3 Gateway harvests SignedFact logs from the DHT or Postgres bridge.
+/// 3. For each valid log, allocate 1 E3 to the producer at creator_did.
+/// 4. Return allocations and computed totals (attested, skipped, returned to spender).
+
+let unyt_allocation = [];
+let total_attested = 0;
+let skipped_authority_only = 0;
+let returned_to_spender = "0";
+
+for (log, i) in consumed_inputs.logs {
+    let allocation = consumed_inputs.spender_allocations[i].data;
+    let fact = get_data_blob(log.data);
+
+    // Exclude authority-only records (privacy_tier == 3).
+    // The credit cannot be issued publicly when the record content is sealed.
+    // Return the parked spend to the spender for these cases.
+    if fact.privacy_tier == 3 {
+        skipped_authority_only += 1;
+        returned_to_spender = add_fuel(returned_to_spender, allocation.amount);
+        continue;
+    }
+
+    // 1 E3 attestation credit per verified SignedFact.
+    // amounts: [base_units, service_units_1, service_units_2]
+    let credit_amount = "1";
+
+    unyt_allocation.push(#{
+        "receiver": fact.creator_did,
+        "amounts": [credit_amount, "0", "0"],
+        "sources": [allocation.source]
+    });
+
+    total_attested += 1;
+}
+
+return #{
+    "output": #{
+        "unyt_allocation": unyt_allocation,
+        "computed_values": #{
+            "total_attested": total_attested,
+            "skipped_authority_only": skipped_authority_only,
+            "returned_to_spender": returned_to_spender
+        }
+    }
+}

--- a/library/economy3_provenance_attestation/output_signature.json
+++ b/library/economy3_provenance_attestation/output_signature.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "unyt_allocation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "receiver": { "type": "string", "description": "Producer's creator_did / Holochain agent key" },
+          "amounts": { "type": "array", "items": { "type": "string" }, "description": "[base_units, service_units_1, service_units_2]" },
+          "sources": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["receiver", "amounts", "sources"]
+      }
+    },
+    "computed_values": {
+      "type": "object",
+      "properties": {
+        "total_attested":         { "type": "number", "description": "Count of attestations that earned credit" },
+        "skipped_authority_only": { "type": "number", "description": "Count of tier-3 records excluded from public credit" },
+        "returned_to_spender":    { "type": "string", "description": "Base units returned to spender for skipped records" }
+      },
+      "required": ["total_attested", "skipped_authority_only", "returned_to_spender"]
+    }
+  },
+  "required": ["unyt_allocation", "computed_values"]
+}

--- a/library/economy3_provenance_attestation/runtime_input_signature.json
+++ b/library/economy3_provenance_attestation/runtime_input_signature.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "consumed_inputs": {
+      "type": "object",
+      "properties": {
+        "spender_allocations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": "object", "additionalProperties": { "type": "string" } },
+              "source": { "type": "string" }
+            },
+            "required": ["amount", "source"]
+          }
+        },
+        "logs": {
+          "description": "Array of Economy3 SignedFact data blob hashes. Each blob contains record_id, resource_hash, material, step, creator_did, qty, unit, privacy_tier.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["spender_allocations", "logs"]
+    }
+  },
+  "required": ["consumed_inputs"]
+}

--- a/library/economy3_provenance_attestation/test/TEST_PROCEDURE.md
+++ b/library/economy3_provenance_attestation/test/TEST_PROCEDURE.md
@@ -1,0 +1,152 @@
+# Economy3 Provenance Attestation — Local Test Procedure
+
+Tests the RAVE against 4 mock SignedFact blobs:
+- 3 public/alias/community records → each earns 1 E3 credit
+- 1 authority-only (tier 3) record → skipped, spend returned to brand
+
+**Expected result:** `total_attested: 3`, `skipped_authority_only: 1`, `returned_to_spender: "1"`
+
+---
+
+## Step 1 — Install and open unyt-sandbox
+
+The v0.54.0 DMGs are on your Desktop. Install the **Holo Hosting** full-arc Silicon DMG.
+
+On first launch: System Settings → Privacy & Security → allow unyt to run.
+
+---
+
+## Step 2 — Upload the 4 mock data blobs
+
+In the app: **DEV MODE → Data Records → Add New Data Record (Custom)**
+
+Upload each blob file in this order and note the hash the app assigns each one:
+
+| # | File | Expected behaviour |
+|---|------|--------------------|
+| 1 | `blob_1_cotton_harvest_public.json` | tier 0 → earns credit |
+| 2 | `blob_2_wool_shear_alias.json` | tier 1 → earns credit |
+| 3 | `blob_3_cotton_gin_community.json` | tier 2 → earns credit |
+| 4 | `blob_4_wool_handoff_authority_only.json` | tier 3 → skipped |
+
+Write down the 4 blob hashes the app assigns. You'll need them in Step 5.
+
+---
+
+## Step 3 — Upload the Agreement Code Template
+
+**DEV MODE → Library → Add Agreement Code Template**
+
+Fill in the fields by copying from the template files:
+
+| Field | Source file |
+|-------|-------------|
+| Title | `Economy3 Provenance Attestation Credit` |
+| Input Schema | paste content of `../runtime_input_signature.json` |
+| Execution Code | paste content of `../execution_code.rhai` |
+| Output Schema | paste content of `../output_signature.json` |
+
+Save the template.
+
+---
+
+## Step 4 — Create a Smart Agreement from the template
+
+**DEV MODE → Library → Create Smart Agreement from Template**
+
+Settings:
+- **Title:** `Economy3 Provenance Attestation — Test Run`
+- **One Time Run:** ON (this is a single test execution)
+- **Aggregate Execution:** OFF
+- **Who can Execute:** Anyone (for local testing)
+
+Roles (2 required):
+
+| Role ID | Description | Qualification |
+|---------|-------------|---------------|
+| `spender` | Brand / buyer parking base units | Any |
+| `executor` | Economy3 Gateway (you, for testing) | Any |
+
+Input Rules — map the two inputs from `runtime_input_signature.json`:
+- `consumed_inputs.logs` → **Executor Provided** (you will supply the blob hashes at execution time)
+- `consumed_inputs.spender_allocations` → **Provided by Role: spender** (the parked spend)
+
+Save the agreement.
+
+---
+
+## Step 5 — Park a spend as the spender
+
+In the app as the spender agent:
+
+**Home → Interact with Smart Agreement → [find your agreement] → Park Spend**
+
+Park **4 Base Units** — one per expected attestation log.
+
+---
+
+## Step 6 — Execute the agreement
+
+As the executor:
+
+**Home → Interact with Smart Agreement → [find your agreement] → Execute**
+
+When prompted for `consumed_inputs.logs`, provide the 4 blob hashes from Step 2:
+
+```json
+[
+  "<hash of blob_1>",
+  "<hash of blob_2>",
+  "<hash of blob_3>",
+  "<hash of blob_4>"
+]
+```
+
+The `spender_allocations` will be drawn from the parked spend automatically.
+
+Execute.
+
+---
+
+## Step 7 — Verify the RAVE output
+
+The RAVE should show:
+
+```json
+{
+  "unyt_allocation": [
+    { "receiver": "uhCAkProducerAlice1111111111111111111111111111111111111111", "amounts": ["1", "0", "0"] },
+    { "receiver": "uhCAkProducerBob22222222222222222222222222222222222222222222", "amounts": ["1", "0", "0"] },
+    { "receiver": "uhCAkCoopNairobi333333333333333333333333333333333333333333", "amounts": ["1", "0", "0"] }
+  ],
+  "computed_values": {
+    "total_attested": 3,
+    "skipped_authority_only": 1,
+    "returned_to_spender": "1"
+  }
+}
+```
+
+Note: `uhCAkProducerDave444...` (blob 4, tier 3) should NOT appear in `unyt_allocation`.
+
+---
+
+## What you're confirming
+
+1. The RAVE engine runs the Rhai code correctly
+2. Tier 3 records are excluded from public credit allocation
+3. The parked spend for the skipped record is returned to the spender
+4. Each producer's `creator_did` is used directly as the receiver address
+5. The `computed_values` totals are correct
+
+---
+
+## If something goes wrong
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Template won't save | Input/output schema JSON syntax error — validate the JSON first |
+| Execution fails with missing input | `consumed_inputs.logs` input rule not set to Executor Provided |
+| All 4 records earn credit | Tier 3 check in execution code not running — verify `privacy_tier` field is present in blob |
+| `returned_to_spender` is wrong | `add_fuel` Rhai function call — check Rhai version compatibility |
+what is this?

--- a/library/economy3_provenance_attestation/test/blob_1_cotton_harvest_public.json
+++ b/library/economy3_provenance_attestation/test/blob_1_cotton_harvest_public.json
@@ -1,0 +1,10 @@
+{
+  "record_id":     "E3-20260412-001",
+  "resource_hash": "a3f9c2d1e4b87650a3f9c2d1e4b87650a3f9c2d1e4b87650a3f9c2d1e4b8765",
+  "material":      "Upland Cotton",
+  "step":          "harvest",
+  "creator_did":   "uhCAkProducerAlice1111111111111111111111111111111111111111",
+  "qty":           500,
+  "unit":          "KG",
+  "privacy_tier":  0
+}

--- a/library/economy3_provenance_attestation/test/blob_2_wool_shear_alias.json
+++ b/library/economy3_provenance_attestation/test/blob_2_wool_shear_alias.json
@@ -1,0 +1,10 @@
+{
+  "record_id":     "E3-20260412-002",
+  "resource_hash": "b4e1d3c2f5a98761b4e1d3c2f5a98761b4e1d3c2f5a98761b4e1d3c2f5a9876",
+  "material":      "Merino Wool",
+  "step":          "shear",
+  "creator_did":   "uhCAkProducerBob22222222222222222222222222222222222222222222",
+  "qty":           120,
+  "unit":          "KG",
+  "privacy_tier":  1
+}

--- a/library/economy3_provenance_attestation/test/blob_3_cotton_gin_community.json
+++ b/library/economy3_provenance_attestation/test/blob_3_cotton_gin_community.json
@@ -1,0 +1,10 @@
+{
+  "record_id":     "E3-20260412-003",
+  "resource_hash": "c5f2e4d3a6b09872c5f2e4d3a6b09872c5f2e4d3a6b09872c5f2e4d3a6b0987",
+  "material":      "Upland Cotton",
+  "step":          "gin",
+  "creator_did":   "uhCAkCoopNairobi333333333333333333333333333333333333333333",
+  "qty":           480,
+  "unit":          "KG",
+  "privacy_tier":  2
+}

--- a/library/economy3_provenance_attestation/test/blob_4_wool_handoff_authority_only.json
+++ b/library/economy3_provenance_attestation/test/blob_4_wool_handoff_authority_only.json
@@ -1,0 +1,10 @@
+{
+  "record_id":     "E3-20260412-004",
+  "resource_hash": "d6a3f5e4b7c10983d6a3f5e4b7c10983d6a3f5e4b7c10983d6a3f5e4b7c1098",
+  "material":      "Wool and Luxury Fibres",
+  "step":          "handoff",
+  "creator_did":   "uhCAkProducerDave44444444444444444444444444444444444444444",
+  "qty":           200,
+  "unit":          "KG",
+  "privacy_tier":  3
+}

--- a/library/economy3_provenance_attestation/test/run_test.rhai
+++ b/library/economy3_provenance_attestation/test/run_test.rhai
@@ -1,0 +1,77 @@
+// Local test harness for economy3_provenance_attestation RAVE logic.
+// Simulates get_data_blob() and add_fuel() since we're outside the Unyt runtime.
+
+// ── Mock get_data_blob ────────────────────────────────────────────────────────
+fn get_data_blob(hash) {
+    let blobs = #{
+        "blob_1": #{ record_id: "E3-20260412-001", material: "Upland Cotton",        step: "harvest", creator_did: "uhCAkProducerAlice", qty: 500, unit: "KG", privacy_tier: 0 },
+        "blob_2": #{ record_id: "E3-20260412-002", material: "Merino Wool",           step: "shear",   creator_did: "uhCAkProducerBob",   qty: 120, unit: "KG", privacy_tier: 1 },
+        "blob_3": #{ record_id: "E3-20260412-003", material: "Upland Cotton",         step: "gin",     creator_did: "uhCAkCoopNairobi",   qty: 480, unit: "KG", privacy_tier: 2 },
+        "blob_4": #{ record_id: "E3-20260412-004", material: "Wool and Luxury Fibres",step: "handoff", creator_did: "uhCAkProducerDave",  qty: 200, unit: "KG", privacy_tier: 3 },
+    };
+    blobs[hash]
+}
+
+// ── Mock add_fuel (string integer addition) ───────────────────────────────────
+fn add_fuel(a, b) {
+    let result = parse_int(a) + parse_int(b.amount);
+    result.to_string()
+}
+
+// ── Mock inputs (mirrors runtime_input_signature.json) ───────────────────────
+let consumed_inputs = #{
+    logs: [
+        #{ data: "blob_1" },
+        #{ data: "blob_2" },
+        #{ data: "blob_3" },
+        #{ data: "blob_4" },
+    ],
+    spender_allocations: [
+        #{ data: #{ amount: "1", source: "spend_src_1" } },
+        #{ data: #{ amount: "1", source: "spend_src_2" } },
+        #{ data: #{ amount: "1", source: "spend_src_3" } },
+        #{ data: #{ amount: "1", source: "spend_src_4" } },
+    ],
+};
+
+// ── RAVE execution code (copied verbatim from execution_code.rhai) ────────────
+let unyt_allocation = [];
+let total_attested = 0;
+let skipped_authority_only = 0;
+let returned_to_spender = "0";
+
+for (log, i) in consumed_inputs.logs {
+    let allocation = consumed_inputs.spender_allocations[i].data;
+    let fact = get_data_blob(log.data);
+
+    if fact.privacy_tier == 3 {
+        skipped_authority_only += 1;
+        returned_to_spender = add_fuel(returned_to_spender, allocation);
+        continue;
+    }
+
+    let credit_amount = "1";
+
+    unyt_allocation.push(#{
+        "receiver": fact.creator_did,
+        "amounts": [credit_amount, "0", "0"],
+        "sources": [allocation.source]
+    });
+
+    total_attested += 1;
+}
+
+// ── Print results ─────────────────────────────────────────────────────────────
+print("=== RAVE OUTPUT ===");
+print(`total_attested:         ${total_attested}`);
+print(`skipped_authority_only: ${skipped_authority_only}`);
+print(`returned_to_spender:    ${returned_to_spender}`);
+print("");
+print("unyt_allocation:");
+for entry in unyt_allocation {
+    print(`  receiver: ${entry.receiver}  amount: ${entry.amounts[0]}`);
+}
+print("");
+print("PASS: tier-3 record excluded =  " + (skipped_authority_only == 1));
+print("PASS: credits issued         =  " + (total_attested == 3));
+print("PASS: spend returned         =  " + (returned_to_spender == "1"));


### PR DESCRIPTION
Rhai Smart Agreement for Economy3's provenance attestation credit loop: brand parks spend, Economy3 Gateway harvests SignedFact logs, producers earn 1 E3 per verified attestation. Authority-only (tier 3) records are excluded and their spend is returned to the brand.