### PR TITLE
feat(agreements): locked-funds agreements — lockbox + holo-hosting locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `lockbox`: a minimal AuthorizedExecutor agreement that holds conserved base-unit funds — parks and locks the remainder, carries the lock forward, spends it down, and unlocks it back to the creator. The proving ground for the locked-funds primitive.
+
 ### Changed
 
+- `holo_hosting_proof_of_service`: lock the unspent base-unit funding instead of returning it to the executor, auto-apply the carried lock on the next run (spend-down), and add an `unlock` executor input to reclaim it; `input_rules` gain `previous_execution` and `unlock`.
 - `holo_hosting_proof_of_service`: pay EdgeNode Hosts for both Holo services through one agreement instance.
 - `holo_hosting_proof_of_service`: price five optional dimensions (storage, gossip, gets, 2 WindTunnel); absent ⇒ 0.
 - `holo_hosting_proof_of_service`: fix the gossip/storage unit-index swap so each dimension credits its own index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `holo_hosting_proof_of_service`: lock the unspent base-unit funding instead of returning it to the executor, auto-apply the carried lock on the next run (spend-down), and add an `unlock` executor input to reclaim it; `input_rules` gain `previous_execution` and `unlock`.
+- `holo_hosting_proof_of_service`: lock the unspent base-unit funding instead of returning it to the executor, auto-apply the carried lock on the next run (spend-down), and add an `unlock` executor input to reclaim it; `input_rules` gain `previous_execution` and `unlock` (both declared in the runtime input signature).
 - `holo_hosting_proof_of_service`: pay EdgeNode Hosts for both Holo services through one agreement instance.
 - `holo_hosting_proof_of_service`: price five optional dimensions (storage, gossip, gets, 2 WindTunnel); absent ⇒ 0.
 - `holo_hosting_proof_of_service`: fix the gossip/storage unit-index swap so each dimension credits its own index.

--- a/library/__system_transaction_fee_collection/runtime_input_signature.json
+++ b/library/__system_transaction_fee_collection/runtime_input_signature.json
@@ -21,7 +21,8 @@
       "type": "object",
       "properties": {
         "receiver": { "type": "string" }
-      }
+      },
+      "required": ["receiver"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_automation_bridging_hf_2_infra/runtime_input_signature.json
+++ b/library/_automation_bridging_hf_2_infra/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "call_method": { "type": "string" },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["call_method"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_automation_bridging_hot_blockchain/runtime_input_signature.json
+++ b/library/_automation_bridging_hot_blockchain/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "coupons": { "type": "object", "additionalProperties": { "type": "string" } },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["coupons"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_bridging_hf_2_infra/runtime_input_signature.json
+++ b/library/_lane_bridging_hf_2_infra/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "call_method": { "type": "string" },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["call_method"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_bridging_hf_2_yf/runtime_input_signature.json
+++ b/library/_lane_bridging_hf_2_yf/runtime_input_signature.json
@@ -56,7 +56,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "call_method": { "type": "string" },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["call_method"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_bridging_infra/runtime_input_signature.json
+++ b/library/_lane_bridging_infra/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "call_method": { "type": "string" },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["call_method"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_bridging_unyt/runtime_input_signature.json
+++ b/library/_lane_bridging_unyt/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "coupons": { "type": "object", "additionalProperties": { "type": "string" } },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["coupons"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_bridging_yf/runtime_input_signature.json
+++ b/library/_lane_bridging_yf/runtime_input_signature.json
@@ -62,7 +62,8 @@
         "previous_execution": { "type": ["object", "null"] },
         "call_method": { "type": "string" },
         "cool_down_period": { "type": "string" }
-      }
+      },
+      "required": ["call_method"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/_lane_proof_of_service/runtime_input_signature.json
+++ b/library/_lane_proof_of_service/runtime_input_signature.json
@@ -21,7 +21,8 @@
       "type": "object",
       "properties": {
         "receiver": { "type": "string" }
-      }
+      },
+      "required": ["receiver"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/aggregate_payment/runtime_input_signature.json
+++ b/library/aggregate_payment/runtime_input_signature.json
@@ -21,7 +21,8 @@
       "type": "object",
       "properties": {
         "receiver": { "type": "string" }
-      }
+      },
+      "required": ["receiver"]
     }
   },
   "required": ["consumed_inputs", "inputs"]

--- a/library/holo_hosting_proof_of_service/agreements/agreement_rules_1.json
+++ b/library/holo_hosting_proof_of_service/agreements/agreement_rules_1.json
@@ -24,6 +24,18 @@
       "instruction": {
         "Fixed": "<Placeholder: price_sheet_data_blob_hash>"
       }
+    },
+    {
+      "name": "previous_execution",
+      "instruction": {
+        "Custom": "GetPreviousExecution"
+      }
+    },
+    {
+      "name": "unlock",
+      "instruction": {
+        "ExecutorProvided": null
+      }
     }
   ],
   "executor_rules": { "Any": null },

--- a/library/holo_hosting_proof_of_service/execution_code.rhai
+++ b/library/holo_hosting_proof_of_service/execution_code.rhai
@@ -61,7 +61,7 @@ if type_of(inputs.previous_execution.data) == "map" {
 // Unlock: return the whole carried balance to the EdgeNode Customer (creator)
 // and emit no new lock. Runs before invoicing so a reclaim never settles host
 // work; sources name every funding source so nothing is left unaccounted.
-if (inputs.unlock.data ?? false) == true {
+if type_of(inputs.unlock) == "map" && inputs.unlock.data == true {
     let carried_back = 0.0;
     let sources = [];
     for alloc in customer_alloc {

--- a/library/holo_hosting_proof_of_service/execution_code.rhai
+++ b/library/holo_hosting_proof_of_service/execution_code.rhai
@@ -44,6 +44,39 @@ let dims = [
 let price_sheet = get_data_blob(inputs.price_sheet_data_blob_hash.data);
 let customer_alloc = consumed_inputs.edge_node_customer_spender_allocations;
 
+// Carried lock from the previous execution (auto-applied), and that execution's
+// hash — the source a lock-funded host payment names. Prepended to the customer
+// funding so the invoice loop draws it down before fresh parked credit.
+let prev_source = ();
+if type_of(inputs.previous_execution.data) == "map" {
+    prev_source = inputs.previous_execution.data.id;
+    let carried = parse_float(inputs.previous_execution.data.output.locked[BASE] ?? "0");
+    if carried > 0.0 {
+        let carried_amount = #{};
+        carried_amount[BASE] = carried.to_string();
+        customer_alloc.insert(0, #{ "data": #{ "amount": carried_amount, "source": prev_source } });
+    }
+}
+
+// Unlock: return the whole carried balance to the EdgeNode Customer (creator)
+// and emit no new lock. Runs before invoicing so a reclaim never settles host
+// work; sources name every funding source so nothing is left unaccounted.
+if (inputs.unlock.data ?? false) == true {
+    let carried_back = 0.0;
+    let sources = [];
+    for alloc in customer_alloc {
+        carried_back = carried_back + parse_float(alloc.data.amount[BASE] ?? "0");
+        sources.push(alloc.data.source);
+    }
+    let out = [];
+    if carried_back > 0.0 {
+        let amt = #{};
+        amt[BASE] = carried_back.to_string();
+        out.push(#{ "receiver": executor_pub_key, "amounts": amt, "sources": sources });
+    }
+    return #{ "output": #{ "unyt_allocation": out } };
+}
+
 let final_unyt_allocation = [];
 let total_payment_expected = 0.0;
 // Service-unit totals per dimension, accumulated across all invoices and credited
@@ -124,31 +157,22 @@ if able_to_pay {
         });
     }
 
-    // Return the executor's unspent base-unit funding (carry-forward is future work).
+    // Lock the unspent base-unit funding (carried lock + fresh parked remainder)
+    // for the next execution, instead of returning it to the executor. The parked
+    // sources are already named in the host payments above, so the full parked
+    // amount is conserved; the carried lock rides forward as the running balance.
     let remaining_customer_alloc = 0.0;
-    let remaining_sources = [];
     for (alloc, i) in customer_alloc {
-        let amt = parse_float(alloc.data.amount[BASE] ?? "0");
-        if amt > 0.0 {
-            remaining_customer_alloc = remaining_customer_alloc + amt;
-            remaining_sources.push(alloc.data.source);
-        }
-    }
-    if remaining_customer_alloc > 0.0 {
-        let remainder_amount = #{};
-        remainder_amount[BASE] = remaining_customer_alloc.to_string();
-        final_unyt_allocation.push(#{
-            "receiver": executor_pub_key,
-            "amounts": remainder_amount,
-            "sources": remaining_sources
-        });
+        remaining_customer_alloc = remaining_customer_alloc + parse_float(alloc.data.amount[BASE] ?? "0");
     }
 
-    return #{
-        "output": #{
-            "unyt_allocation": final_unyt_allocation
-        }
-    };
+    let output = #{ "unyt_allocation": final_unyt_allocation };
+    if remaining_customer_alloc > 0.0 {
+        let locked = #{};
+        locked[BASE] = remaining_customer_alloc.to_string();
+        output.locked = locked;
+    }
+    return #{ "output": output };
 } else {
     throw "For execution to succeed, a payment of " + total_payment_expected.to_string() + " ZF must be sent to this agreement to settle outstanding invoices.";
 }

--- a/library/holo_hosting_proof_of_service/execution_code.rhai
+++ b/library/holo_hosting_proof_of_service/execution_code.rhai
@@ -143,6 +143,24 @@ for (value, vi) in consumed_inputs.invoice_payloads {
 }
 
 if able_to_pay {
+    // Unspent base-unit funding (carried lock + fresh parked remainder) to lock for
+    // the next execution instead of returning it to the executor, and the sources
+    // that still carry a remainder. Every source that funds the new lock must stay
+    // named: a parked spend counts as conserved input only when a `unyt_allocation`
+    // names its source (fully-spent sources are already named on their host
+    // payments; the carried lock rides forward as the predecessor's running balance
+    // and needs no naming). They are named on the executor's dimension allocation
+    // below.
+    let remaining_customer_alloc = 0.0;
+    let remaining_sources = [];
+    for (alloc, i) in customer_alloc {
+        let amt = parse_float(alloc.data.amount[BASE] ?? "0");
+        if amt > 0.0 {
+            remaining_customer_alloc = remaining_customer_alloc + amt;
+            remaining_sources.push(alloc.data.source);
+        }
+    }
+
     // Credit each metered dimension's total to the executor on its own unit index.
     let executor_amounts = #{};
     let has_dimension_totals = false;
@@ -152,21 +170,30 @@ if able_to_pay {
             has_dimension_totals = true;
         }
     }
+    // Name the invoice sources plus the lock-funding remainder sources on the
+    // executor's (non-zero) dimension credit, so the remainder stays conserved
+    // without a dedicated `{ BASE: "0" }` allocation, which the ledger rejects at
+    // settlement (a zero MonetaryUnit amount is uncollectable).
+    //
+    // KNOWN LIMITATION (deferred): the remainder sources are named only when there
+    // is metered host work to credit. A lock with no metered work at all (empty
+    // invoices, or logs whose counts are all zero) has no non-zero allocation to
+    // carry the names, so those sources go unnamed and Rule 7 rejects the run — one
+    // facet of the broader "a zero MonetaryUnit amount is uncollectable at
+    // settlement" issue (a pure hold cannot name its sources with a `{ BASE: "0" }`
+    // allocation either). Deferred to that follow-up rather than worked around here
+    // with an empty-amount allocation, which would settle but emit a phantom
+    // zero-value deposit to the executor.
     if has_dimension_totals {
+        let executor_sources = consumed_inputs.invoice_payloads.map(|p| p.link_hash);
+        for s in remaining_sources {
+            executor_sources.push(s);
+        }
         final_unyt_allocation.push(#{
             "receiver": executor_pub_key,
             "amounts": executor_amounts,
-            "sources": consumed_inputs.invoice_payloads.map(|p| p.link_hash)
+            "sources": executor_sources
         });
-    }
-
-    // Lock the unspent base-unit funding (carried lock + fresh parked remainder)
-    // for the next execution, instead of returning it to the executor. The parked
-    // sources are already named in the host payments above, so the full parked
-    // amount is conserved; the carried lock rides forward as the running balance.
-    let remaining_customer_alloc = 0.0;
-    for (alloc, i) in customer_alloc {
-        remaining_customer_alloc = remaining_customer_alloc + parse_float(alloc.data.amount[BASE] ?? "0");
     }
 
     let output = #{ "unyt_allocation": final_unyt_allocation };

--- a/library/holo_hosting_proof_of_service/execution_code.rhai
+++ b/library/holo_hosting_proof_of_service/execution_code.rhai
@@ -50,7 +50,10 @@ let customer_alloc = consumed_inputs.edge_node_customer_spender_allocations;
 let prev_source = ();
 if type_of(inputs.previous_execution.data) == "map" {
     prev_source = inputs.previous_execution.data.id;
-    let carried = parse_float(inputs.previous_execution.data.output.locked[BASE] ?? "0");
+    // A prior run that fully spent its funding omits `locked`, so default it to
+    // an empty map before indexing — `()[BASE]` would be a Rhai runtime error.
+    let carried_locked = inputs.previous_execution.data.output.locked ?? #{};
+    let carried = parse_float(carried_locked[BASE] ?? "0");
     if carried > 0.0 {
         let carried_amount = #{};
         carried_amount[BASE] = carried.to_string();

--- a/library/holo_hosting_proof_of_service/output_signature.json
+++ b/library/holo_hosting_proof_of_service/output_signature.json
@@ -12,7 +12,8 @@
         },
         "required": ["receiver", "amounts", "sources"]
       }
-    }
+    },
+    "locked": { "type": "object", "additionalProperties": { "type": "string" } }
   },
   "required": ["unyt_allocation"]
 }

--- a/library/holo_hosting_proof_of_service/runtime_input_signature.json
+++ b/library/holo_hosting_proof_of_service/runtime_input_signature.json
@@ -58,7 +58,8 @@
     "inputs": {
       "type": "object",
       "properties": {
-        "price_sheet_data_blob_hash": { "type": "string" }
+        "price_sheet_data_blob_hash": { "type": "string" },
+        "unlock": { "type": "boolean" }
       },
       "required": ["price_sheet_data_blob_hash"]
     }

--- a/library/holo_hosting_proof_of_service/runtime_input_signature.json
+++ b/library/holo_hosting_proof_of_service/runtime_input_signature.json
@@ -58,6 +58,7 @@
     "inputs": {
       "type": "object",
       "properties": {
+        "previous_execution": { "type": ["object", "null"] },
         "price_sheet_data_blob_hash": { "type": "string" },
         "unlock": { "type": "boolean" }
       },

--- a/library/lockbox/agreement_definition_input.json
+++ b/library/lockbox/agreement_definition_input.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "expected_roles": {
+      "type": "array",
+      "items": [
+        {
+          "const": {
+            "id": "locker_spender",
+            "parked_link_type": "ParkedSpendCredit"
+          }
+        }
+      ],
+      "minItems": 1,
+      "maxItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "required": ["expected_roles"],
+  "additionalProperties": false
+}

--- a/library/lockbox/agreements/agreement_rules_1.json
+++ b/library/lockbox/agreements/agreement_rules_1.json
@@ -1,0 +1,36 @@
+{
+  "title": "Lockbox (locked-funds proving agreement)",
+  "input_rules": [
+    {
+      "name": "locker_spender_allocations",
+      "instruction": { "ProvidedBy": "locker_spender" }
+    },
+    {
+      "name": "previous_execution",
+      "instruction": { "Custom": "GetPreviousExecution" }
+    },
+    {
+      "name": "unlock",
+      "instruction": { "ExecutorProvided": null }
+    },
+    {
+      "name": "payout_amount",
+      "instruction": { "ExecutorProvided": null }
+    },
+    {
+      "name": "payout_receiver",
+      "instruction": { "ExecutorProvided": null }
+    }
+  ],
+  "executor_rules": { "Any": null },
+  "roles": [
+    {
+      "ct_role_id": "locker_spender",
+      "display_name": "Locker",
+      "description": "Parks funds and runs the lockbox; holds and reclaims the locked balance. Must be the sole authorized executor (locking requires a single successor).",
+      "qualification": { "Any": null }
+    }
+  ],
+  "tags": [{ "Public": "lockbox" }, { "Public": "example" }],
+  "permissions": { "Default": null }
+}

--- a/library/lockbox/execution_code.rhai
+++ b/library/lockbox/execution_code.rhai
@@ -46,7 +46,7 @@ if carried > 0.0 {
 let available = carried + parked;
 
 // Unlock: return the whole balance to the creator (the executor); no new lock.
-if (inputs.unlock.data ?? false) == true {
+if type_of(inputs.unlock) == "map" && inputs.unlock.data == true {
     let out = [];
     if available > 0.0 {
         let amt = #{};

--- a/library/lockbox/execution_code.rhai
+++ b/library/lockbox/execution_code.rhai
@@ -56,18 +56,43 @@ if type_of(inputs.unlock) == "map" && inputs.unlock.data == true {
     return #{ "output": #{ "unyt_allocation": out } };
 }
 
-// Otherwise pay the requested amount and lock the rest.
-let payout = parse_float(inputs.payout_amount.data ?? "0");
+// Otherwise pay the requested amount and lock the rest. Both payout inputs are
+// optional (runtime_input_signature.json): an omitted/absent `payout_amount`
+// means a pure hold (pay 0). A negative payout is rejected — it would make
+// `remaining` exceed what was parked/carried and mint locked funds past the
+// first-law check.
+let payout = 0.0;
+if type_of(inputs.payout_amount) == "map" {
+    payout = parse_float(inputs.payout_amount.data ?? "0");
+}
+if payout < 0.0 {
+    throw "lockbox: payout_amount must not be negative";
+}
 if payout > available {
     throw "lockbox: payout " + payout.to_string() + " exceeds available " + available.to_string();
 }
 
 let allocation = [];
 if payout > 0.0 {
+    if type_of(inputs.payout_receiver) != "map" {
+        throw "lockbox: payout_receiver is required for a nonzero payout";
+    }
     let amt = #{};
     amt[BASE] = payout.to_string();
     allocation.push(#{
         "receiver": inputs.payout_receiver.data,
+        "amounts": amt,
+        "sources": sources
+    });
+} else if parked > 0.0 {
+    // Pure hold of freshly-parked funds: name the parked sources with a
+    // zero-amount allocation so they count as conserved input — a parked source
+    // is an input only when a `unyt_allocation` names it (a carried lock is the
+    // running balance inherited from the predecessor and needs no naming).
+    let amt = #{};
+    amt[BASE] = "0";
+    allocation.push(#{
+        "receiver": executor_pub_key,
         "amounts": amt,
         "sources": sources
     });

--- a/library/lockbox/execution_code.rhai
+++ b/library/lockbox/execution_code.rhai
@@ -1,0 +1,83 @@
+/// Subject: lockbox — a minimal agreement that HOLDS conserved base-unit funds,
+/// the proving ground for the locked-funds primitive. It parks funds and locks
+/// the unspent remainder, carries the lock to the next execution, spends it
+/// down, and unlocks it back to the creator. Base unit "0" only.
+///
+/// Users:
+/// - Locker (spender + executor): parks base-unit credit and runs the agreement.
+/// - Payout receiver: paid the requested amount out of the available balance.
+///
+/// Inputs:
+/// - locker_spender_allocations: base-unit credit parked this run (pre-processor).
+/// - previous_execution (Custom GetPreviousExecution): { id, output } of the last
+///   run — its `output.locked` is the carried balance, its `id` the source a
+///   lock-funded allocation names.
+/// - unlock (ExecutorProvided bool): return the whole balance to the creator.
+/// - payout_amount / payout_receiver (ExecutorProvided): pay this much to this
+///   receiver, lock the rest.
+///
+/// Note: locking newly-parked funds requires a nonzero payout so the parked
+/// source is named (the conservation rule counts a parked source only when an
+/// allocation references it); a carried lock needs no naming — it is the running
+/// balance, inherited from the predecessor unconditionally.
+
+let BASE = "0";
+
+// Carried lock + the previous execution's hash (the lock source next run names).
+let carried = 0.0;
+let prev_source = ();
+if type_of(inputs.previous_execution.data) == "map" {
+    prev_source = inputs.previous_execution.data.id;
+    let locked = inputs.previous_execution.data.output.locked ?? #{};
+    carried = parse_float(locked[BASE] ?? "0");
+}
+
+// Newly parked funds this run, with their sources.
+let parked = 0.0;
+let sources = [];
+for alloc in consumed_inputs.locker_spender_allocations {
+    parked = parked + parse_float(alloc.data.amount[BASE] ?? "0");
+    sources.push(alloc.data.source);
+}
+if carried > 0.0 {
+    sources.push(prev_source);
+}
+
+let available = carried + parked;
+
+// Unlock: return the whole balance to the creator (the executor); no new lock.
+if (inputs.unlock.data ?? false) == true {
+    let out = [];
+    if available > 0.0 {
+        let amt = #{};
+        amt[BASE] = available.to_string();
+        out.push(#{ "receiver": executor_pub_key, "amounts": amt, "sources": sources });
+    }
+    return #{ "output": #{ "unyt_allocation": out } };
+}
+
+// Otherwise pay the requested amount and lock the rest.
+let payout = parse_float(inputs.payout_amount.data ?? "0");
+if payout > available {
+    throw "lockbox: payout " + payout.to_string() + " exceeds available " + available.to_string();
+}
+
+let allocation = [];
+if payout > 0.0 {
+    let amt = #{};
+    amt[BASE] = payout.to_string();
+    allocation.push(#{
+        "receiver": inputs.payout_receiver.data,
+        "amounts": amt,
+        "sources": sources
+    });
+}
+
+let output = #{ "unyt_allocation": allocation };
+let remaining = available - payout;
+if remaining > 0.0 {
+    let locked = #{};
+    locked[BASE] = remaining.to_string();
+    output.locked = locked;
+}
+return #{ "output": output };

--- a/library/lockbox/other_options.json
+++ b/library/lockbox/other_options.json
@@ -1,0 +1,6 @@
+{
+  "one_time_run": false,
+  "aggregate_execution": true,
+  "tags": [{ "Public": "lockbox" }],
+  "permissions": { "Default": null }
+}

--- a/library/lockbox/output_signature.json
+++ b/library/lockbox/output_signature.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "unyt_allocation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "receiver": { "type": "string" },
+          "amounts": { "type": "object", "additionalProperties": { "type": "string" } },
+          "sources": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["receiver", "amounts", "sources"]
+      }
+    },
+    "locked": { "type": "object", "additionalProperties": { "type": "string" } }
+  },
+  "required": ["unyt_allocation"]
+}

--- a/library/lockbox/runtime_input_signature.json
+++ b/library/lockbox/runtime_input_signature.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "consumed_inputs": {
+      "type": "object",
+      "properties": {
+        "locker_spender_allocations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": "object", "additionalProperties": { "type": "string" } },
+              "source": { "type": "string" }
+            },
+            "required": ["amount", "source"]
+          }
+        }
+      },
+      "required": ["locker_spender_allocations"]
+    },
+    "inputs": {
+      "type": "object",
+      "properties": {
+        "previous_execution": { "type": "object" },
+        "unlock": { "type": "boolean" },
+        "payout_amount": { "type": "string" },
+        "payout_receiver": { "type": "string" }
+      }
+    }
+  },
+  "required": ["consumed_inputs", "inputs"]
+}


### PR DESCRIPTION
## What & why

The smart-agreement side of the locked-funds primitive (Unyt RAVE engine): an agreement can **hold** conserved base-unit funds and carry them forward instead of paying them out.

Consumed by the paired `unyt-sandbox/unyt` PR (`feat/locked-funds` → `develop`), which lands the engine + DNA support. **Merge this first** — that PR pins this repo's merged commit.

## Delivered

- **`lockbox`** (UNYT-925 proving agreement) — a minimal AuthorizedExecutor agreement that parks and locks base-unit funds, carries the lock forward, spends it down, and unlocks it back to the creator: the end-to-end proving ground for the primitive.
- **`holo_hosting_proof_of_service`** (UNYT-926) — adopts the spend-down policy: locks the unspent customer funding instead of returning it, auto-applies the carried lock on the next run, and adds an `unlock` executor input to reclaim it. `input_rules` gain `previous_execution` + `unlock`; the `unlock` input is guarded against a null value.

## Verified

Both agreements are driven end-to-end on a real conductor by the sweettests in the paired `unyt-sandbox/unyt` PR (lockbox lifecycle ~60s; holo-hosting EdgeNode+WindTunnel ~130s). Rhai changes need no wasm rebuild, so the agreements are validated as loaded at runtime.

## Notes

- Base: `main`. Ship order: merge this first; the `unyt-sandbox/unyt` PR then pins the merged commit.
- Follow-up (workshop backlog **B66**): the holo_hosting default `executor_rules` is `Any`, but locking requires `AuthorizedExecutor` (the DNA guard enforces it and instantiation sets it) — reconcile the template default / document the requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **lockbox** agreement flow to lock conserved base-unit funds, carry balances across runs, support payouts, and optionally unlock all remaining funds back to the creator.
  * Extended **holo_hosting_proof_of_service** with **previous execution** carry-forward and an **unlock** input for automated reclaim.
* **Bug Fixes**
  * Updated hosting proof-of-service settlement to preserve unspent base-unit funding for the next run as locked value (instead of immediately returning it).
* **Documentation**
  * Updated **CHANGELOG** with new “Unreleased → Added” and “Unreleased → Changed” entries.
* **Schema & Validation Improvements**
  * Added/updated JSON schemas and runtime input/output signatures, including new `locked` handling and stricter required-field validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->